### PR TITLE
Update for 0.10 compiler release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,19 +15,19 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "~0.13.0",
-    "purescript-arrays": "~0.4.2",
-    "purescript-control": "~0.3.1",
-    "purescript-datetime": "^0.9.0",
-    "purescript-either": "~0.2.3",
-    "purescript-foldable-traversable": "~0.4.0",
-    "purescript-foreign": "~0.7.0",
-    "purescript-integers": "~0.2.1",
-    "purescript-node-buffer": "~0.2.0",
-    "purescript-transformers": "~0.8.1"
+    "purescript-aff": "^2.0.1",
+    "purescript-arrays": "^3.0.1",
+    "purescript-control": "^2.0.0",
+    "purescript-datetime": "^2.0.0",
+    "purescript-either": "^2.0.0",
+    "purescript-foldable-traversable": "^2.0.0",
+    "purescript-foreign": "^3.0.1",
+    "purescript-integers": "^2.1.0",
+    "purescript-node-buffer": "^2.0.0",
+    "purescript-transformers": "^2.0.2"
   },
   "devDependencies": {
-    "purescript-console": "~0.1.1",
-    "purescript-spec": "~0.7.2"
+    "purescript-console": "^2.0.0",
+    "purescript-spec": "~0.10.0"
   }
 }

--- a/src/Database/AnyDB/Pool.purs
+++ b/src/Database/AnyDB/Pool.purs
@@ -7,21 +7,10 @@ module Database.AnyDB.Pool
   , closePool
   ) where
 
-import Prelude
-import Control.Alt
-import Control.Monad.Eff
-import Control.Monad.Trans
-import Control.Monad.Aff
-import Control.Monad.Eff.Class
-import Control.Monad.Eff.Exception(Error(), error)
-import Control.Monad.Error.Class (throwError)
-import Data.Either
-import Data.Array
-import Data.Foreign
-import Data.Foreign.Class
-import Data.Maybe
-import Data.Traversable (sequence)
-import Database.AnyDB
+import Prelude (Unit, ($))
+import Control.Monad.Eff (Eff)
+import Control.Monad.Aff (Aff)
+import Database.AnyDB (Connection, ConnectionInfo, ConnectionString, DB, mkConnectionString)
 
 foreign import data Pool :: *
 

--- a/src/Database/AnyDB/SqlValue.purs
+++ b/src/Database/AnyDB/SqlValue.purs
@@ -1,6 +1,6 @@
 module Database.AnyDB.SqlValue
   ( SqlValue()
-  , IsSqlValue
+  , class IsSqlValue
   , toSql
   ) where
 

--- a/src/Database/AnyDB/Transaction.purs
+++ b/src/Database/AnyDB/Transaction.purs
@@ -3,10 +3,9 @@ module Database.AnyDB.Transaction
   , withTransaction
   ) where
 
-import Prelude
-import Control.Monad.Aff
-import Control.Monad.Eff
-import Database.AnyDB
+import Prelude (Unit, bind, pure)
+import Control.Monad.Aff (Aff)
+import Database.AnyDB (Connection, DB)
 
 foreign import data Transaction :: *
 
@@ -18,7 +17,7 @@ withTransaction p con = do
   tx  <- beginTransaction con
   res <- p con
   commitTransaction tx
-  return res
+  pure res
 
 foreign import beginTransaction :: forall eff. Connection -> Aff (db :: DB | eff) Transaction
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,11 +1,19 @@
 module Test.Main where
 
-import qualified Test.Sqlite3 as SL
-import qualified Test.Postgres as PG
+import Prelude (Unit)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE)
+import Node.Process (PROCESS)
+
+import Database.AnyDB (DB)
+
+import Test.Sqlite3 as SL
+--import Test.Postgres as PG
 
 import Test.Spec.Runner           (run)
 import Test.Spec.Reporter.Console (consoleReporter)
 
+main :: Eff (console :: CONSOLE, db :: DB, process :: PROCESS) Unit
 main = run [consoleReporter] do
   SL.main
   --PG.main

--- a/test/Postgres.purs
+++ b/test/Postgres.purs
@@ -10,7 +10,6 @@ import Control.Monad.Eff.Console
 import Control.Monad.Eff
 import Control.Monad.Eff.Class
 import Control.Monad.Cont.Trans
-import Control.Monad.Trans
 import Data.Array
 import Data.Foldable
 import Data.Either
@@ -45,7 +44,7 @@ exampleUsingWithConnection = withConnection connectionInfo $ \c -> do
   execute_ (Query "insert into artist values ('Led Zeppelin', 1968)") c
   execute_ (Query "insert into artist values ('Deep Purple', 1968)") c
   year <- queryValue_ (Query "insert into artist values ('Fairport Convention', 1967) returning year" :: Query Number) c
-  liftEff $ print (show year)
+  liftEff $ log (show year)
   artists <- query_ (Query "select * from artist" :: Query Artist) c
   liftEff $ printRows artists
 

--- a/test/Shared.purs
+++ b/test/Shared.purs
@@ -1,8 +1,7 @@
 module Test.Shared where
 
 import Prelude
-import Data.Foreign
-import Data.Foreign.Class
+import Data.Foreign.Class (class IsForeign, readProp)
 
 data Artist = Artist
   { name :: String
@@ -16,7 +15,7 @@ instance artistIsForeign :: IsForeign Artist where
   read obj = do
     n <- readProp "name" obj
     y <- readProp "year" obj
-    return $ Artist { name: n, year: y }
+    pure $ Artist { name: n, year: y }
 
 instance artistEq :: Eq Artist where
   eq (Artist {name: n1, year: y1}) (Artist {name: n2, year: y2}) = n1 == n2 && y1 == y2

--- a/test/Sqlite3.purs
+++ b/test/Sqlite3.purs
@@ -1,16 +1,17 @@
 module Test.Sqlite3 where
 
-import Prelude
-import Test.Shared
-import Control.Monad.Aff
-import Database.AnyDB
+import Prelude (Unit, bind)
+import Test.Shared (Artist(..))
+import Database.AnyDB (ConnectionInfo(..), DB, Query(..), execute_, query_, withConnection)
 
-import Test.Spec                  (describe, pending, it)
+import Test.Spec                  (Spec, describe, it)
 import Test.Spec.Assertions       (shouldEqual)
 
+connectionInfo :: ConnectionInfo
 connectionInfo = Sqlite3 { filename: "test"
                          , memory: true }
 
+main :: forall r. Spec (db :: DB | r) Unit
 main = do
   describe "integration test Sqlite3 + Photobooth type" do
     it "should make a db, drop it, make it again, insert an Artist row, and get it back out" do


### PR DESCRIPTION
Change to `liftError` is a bit dubious. `read` now returns an NonEmptyList of Errors so I just took the head of that. Thoughts?